### PR TITLE
Miscellaneous clean up fixes

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ title }} - Inklusio</title>
+    <title>{% if title %}{{ title }} - {% endif %}Inklusio</title>
     <meta name="Description" content="{{ renderData.description or description or metadata.description }}">
 
     <link rel="stylesheet" href="{{ '/css/my-bootstrap.css' | url }}">
@@ -13,7 +13,6 @@
   <div class="site-container">
     <header class="site-header">
         <a class="skiptomain" href="#main">Spring til hovedindhold</a>
-
         <div class="container-xxxl">
             <nav class="navbar navbar-expand-lg navbar-dark px-0" aria-label="Top menu">
                 <a class="navbar-brand" href="/">
@@ -27,7 +26,7 @@
                 <div class="navbar-collapse collapse" id="collapsingNavbar4">
                     <div class="navbar-nav">
                     {%- for entry in collections.all | eleventyNavigation %}
-                        <a class="nav-item nav-link text-white {% if entry.url == page.url %} active {% endif %} mr-4" {% if entry.url == page.url %} aria-current="page"{% endif %} href="{{ entry.url | url }}">{{ entry.title }}</a>
+                        <a class="nav-item nav-link text-decoration-underline-hover text-white {% if entry.url == page.url %} text-decoration-underline {% endif %} mr-4" {% if entry.url == page.url %} aria-current="page"{% endif %} href="{{ entry.url | url }}">{{ entry.title }}</a>
                     {%- endfor %}
 	  		        </div>
                 </div>
@@ -36,7 +35,7 @@
     </header>
 
     <main id="main" tabindex="-1" {% if templateClass %} class="{{ templateClass }}"{% endif %}>
-        <div class="container-xxl">
+        <div class="container-xxl py-4">
             {{ content | safe }}
         </div>
     </main>
@@ -57,8 +56,7 @@
                 </div>
                 <div class="col-12 col-sm-12 col-md-12  col-lg-4 col-xl-4 ">
                     <p class="my-3">
-                        Telefon: +45 26 34 34 55
-
+                        <span id="phoneDesc">Telefon:</span> <a aria-labelledby="phoneDesc" href="tel:+45 26 34 34 55" class="text-white text-decoration-underline">+45 26 34 34 55</a>
                     </p>
                 </div>
             </div>

--- a/_includes/layouts/contact.njk
+++ b/_includes/layouts/contact.njk
@@ -2,23 +2,14 @@
 layout: layouts/base.njk
 templateClass: tmpl-contact
 ---
-        <div id="Contact-row" class="row m-0 pl-2 pr-2">
-
-           
-             
-            <div id="Contact-left" class="col-12 col-sm-12 col-md-6 col-lg-6 col-xl-5 offset-xl-1">
-                <h1 class="mt-4">{{ title }}</h1>
-{{ content | safe }}
-            </div>
-            <div id="Contact-right" class="col-12 col-sm-12 col-md-6 col-lg-6 col-xl-5">
-                <h1 class="mt-4">Book et møde</h1>
-
-<div class="calendly-inline-widget" data-url="https://calendly.com/skotkjerra/letsconnect?hide_event_type_details=1&text_color=082840&primary_color=28a4a4" style="min-width:320px;height:630px;">
-</div>
-<script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js"></script>
-</div>
-
-
-        </div>
-
+<div class="row">
+    <div class="col-12 col-sm-12 col-md-6 col-lg-6 col-xl-5 offset-xl-1">
+        <h1>{{ title }}</h1>
+        {{ content | safe }}
     </div>
+    <div class="col-12 col-sm-12 col-md-6 col-lg-6 col-xl-5">
+        <h2>Book et møde</h2>
+        <div class="calendly-inline-widget" data-url="https://calendly.com/skotkjerra/letsconnect?hide_event_type_details=1&text_color=082840&primary_color=28a4a4" style="min-width:320px;height:630px;"></div>
+        <script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js"></script>
+    </div>
+</div>

--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -2,7 +2,7 @@
 layout: layouts/base.njk
 templateClass: tmpl-post
 ---
-<h1 class="mt-4"> {{ title }} </h1>
+{% if title %}<h1>{{ title }}</h1>{% endif %}
 {% if author or date %}<p>Skrevet{% if author  %} af {{ author }}{% endif %}{% if date %} den <time datetime="{{ date|htmlDateString }}">{{ page.date|readableDate }}{% endif %}</time></p>{% endif %}
 {{ content | safe }}
 

--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -1,16 +1,17 @@
-<ul reversed class="postlist" style="counter-reset: start-from {{ (postslistCounter or postslist.length) + 1 }}">
+<ul reversed style="counter-reset: start-from {{ (postslistCounter or postslist.length) + 1 }}">
 {% for post in postslist | reverse %}
-  <li class="mb-2 postlist-item{% if post.url == url %} postlist-item-active{% endif %}">
-    <span role="heading" aria-level="2">
-	<a href="{{ post.url | url }}" class="postlist-link">{% if post.data.title %}{{ post.data.title }}{% else %}<code>{{ post.url }}</code>{% endif %}</a>
+  <li class="mb-3">
+    <span role="heading" aria-level="3">
+	    <a href="{{ post.url | url }}" class="postlist-link">{% if post.data.title %}{{ post.data.title }}{% else %}<code>{{ post.url }}</code>{% endif %}</a>
     </span>
-	<time class="postlist-date" datetime="{{ post.date | htmlDateString }}">{{ post.date | readableDate }}</time>
-    {% for tag in post.data.tags %}
+	  <time class="postlist-date" datetime="{{ post.date | htmlDateString }}">{{ post.date | readableDate }}</time>
+    <p class="m-0"><span class="sr-only">Tags til denne artikel: </span>{% for tag in post.data.tags %}
       {%- if collections.tagList.indexOf(tag) != -1 -%}
       {% set tagUrl %}/tags/{{ tag }}/{% endset %}
-      <a href="{{ tagUrl | url }}" class="tag">{{ tag }}</a>
+      <a href="{{ tagUrl | url }}" class="badge badge-dark">{{ tag }}</a>
       {%- endif -%}
     {% endfor %}
-  </li>
+    </p>
+    </li>
 {% endfor %}
 </ul>

--- a/_includes/sass/my-bootstrap.scss
+++ b/_includes/sass/my-bootstrap.scss
@@ -51,11 +51,6 @@ body {
   font-size: 1.2em;
 }
 
-.nav-link.active,
-.navlink:hover {
-  text-decoration: underline;
-}
-
 a.skiptomain {
   left:-999px;
   position:absolute;
@@ -66,7 +61,7 @@ a.skiptomain {
   z-index:-999;
 }
 
-a.skiptomain:focus, a.skip-main:active {
+a.skiptomain:focus, a.skiptomain:active {
   color: #fff;
   background-color:#000;
   left: auto;
@@ -82,3 +77,12 @@ a.skiptomain:focus, a.skip-main:active {
   font-size:1.2em;
   z-index:999;
 }
+
+/*
+ * Bootstrap has a utility class "text-decoration-none" but not a "text-decoration-underline". Let's add that and
+ * a similar one for forcing underlines on hover.
+ */
+ .text-decoration-underline,
+ .text-decoration-underline-hover:hover {
+   text-decoration: underline!important;
+ }

--- a/index.njk
+++ b/index.njk
@@ -5,9 +5,9 @@ eleventyNavigation:
   key: Hjem
   order: 1
 ---
-<div id="content-row" class="row">
-    <div id="ContentLeftCol" class="col-12 col-sm-12 col-md-12 col-lg-4 col-xl-4 ">
-        <h1 class="mt-4">Vi gør webtilgængelighed overskueligt</h1>
+<div class="row">
+    <div class="col-12 col-sm-12 col-md-12 col-lg-4 col-xl-4 ">
+        <h1>Vi gør webtilgængelighed overskueligt</h1>
         <p>Inklusio ApS er en konsulentvirksomhed der rådgiver omkring digital inklusion og webtilgængelighed. Vi vil gerne være din sparringspartner fra opstart af proces til test af færdig løsning. </p>
         <p><a href="tel:+4526343455">Ring til os på +45&nbsp;26&nbsp;34&nbsp;34&nbsp;55</a></p>
         <p>Vi kan hjælpe med alt hvad der vedrører digital inklusion og webtilgængelighed:<p>
@@ -20,11 +20,11 @@ eleventyNavigation:
         <p>Vi lægger vægt på faglighed og ansvarlighed.</p>
         <p>Det er et mål i alle vores projekter at overføre mest mulig af vores viden til dig som kunde. Derfor laver vi ikke tingene <strong>for</strong> dig, men <strong>med</strong> dig.</p>
     </div>
-    <div id="ContentMiddleCol" class=" col-12 col-sm-12 col-md-12  col-lg-4 col-xl-4 ">
+    <div class="col-12 col-sm-12 col-md-12  col-lg-4 col-xl-4 ">
         <img src="img/SES-black-and-white.jpg" class="img-fluid" alt="Stein Erik Skotkjerra"  />
     </div>
-    <div id="ContentRightCol" class="col-12 col-sm-12 col-md-12 col-lg-4 col-xl-4">
-        <h2 class="mt-4">Aktuelt</h2>
+    <div class="col-12 col-sm-12 col-md-12 col-lg-4 col-xl-4">
+        <h2>Aktuelt</h2>
         {% set postslist = collections.posts | head(-3) %}
         {% set postslistCounter = collections.posts | length %}
         {% include "postslist.njk" %}

--- a/posts/er-du-klar-til-den-helt-store-tilgængelighedsopgradering.md
+++ b/posts/er-du-klar-til-den-helt-store-tilgængelighedsopgradering.md
@@ -11,21 +11,20 @@ tags:
 
 Har du også fået en mail fra Siteimprove om ”Opgradering af dit Siteimprove Accessibility-modul i løbet af 3 måneder”?
 
-Det skal ikke være nogen hemmelighed, at det er en opgradering, som vi hos Inklusio glæder os meget til. 
+Det skal ikke være nogen hemmelighed, at det er en opgradering, som vi hos Inklusio glæder os meget til.
 
-Og vi synes også, at du skulle glæde dig til den, for det bliver SÅ godt! 
+Og vi synes også, at du skulle glæde dig til den, for det bliver SÅ godt!
 
 Blandt fordelene kan nævnes, at du kan sætte mål for din organisation og filtrere alt irrelevant væk, og at de helt nye tilgængelighedschecks er super præcise – og baseret på de samme regler som den monitorering for webtilgængelighedsloven, som vi hjælper Digitaliseringsstyrelsen med at lave.
 
 Vi har allerede hjulpet flere af både vores offentlige og private kunder med at komme godt i gang med det nye NextGen Siteimprove Accessibility, mens det var under udvikling.
 
-Som alt software fra Siteimprove er det nemt at komme i gang med, især hvis du allerede arbejder med Siteimprove Accessibility. 
+Som alt software fra Siteimprove er det nemt at komme i gang med, især hvis du allerede arbejder med Siteimprove Accessibility.
 
-Men hvis du kunne bruge en hånd til at finde ud af, hvordan din organisation får det maksimale udbytte af jeres tilgængelighedssoftware, så står vi klar til at hjælpe dig i gang. 
+Men hvis du kunne bruge en hånd til at finde ud af, hvordan din organisation får det maksimale udbytte af jeres tilgængelighedssoftware, så står vi klar til at hjælpe dig i gang.
 
 Vi kunne for eksempel lave en workshop, hvor kigger på softwaren sammen og hjælper dig med at indstille platformen til din organisations behov. Eller et kursus for dine webredaktører, hvor vi genopfrisker deres viden om tilgængelighed med udgangspunkt i det nye NextGen Accessibility og sikrer, at de har styr på hvordan de bruger det i deres daglige arbejde.
 
 Kontakt os for at høre mere om, hvordan vi kan hjælpe dig med webtilgængelighed: Ring til Stein Erik på +45 26 34 34 55 eller send en mail til ses@inklusio.dk.
 
-Og husk også at tilmelde dig en opgradering af din Siteimprove Accessibility allerede nu: 
-https://hello.siteimprove.com/da-dk/new-accessibility/opt-in
+Og husk også at tilmelde dig en opgradering af din Siteimprove Accessibility allerede nu: https://hello.siteimprove.com/da-dk/new-accessibility/opt-in

--- a/posts/prm-inklusio-inqlude-it-samarbejde.md
+++ b/posts/prm-inklusio-inqlude-it-samarbejde.md
@@ -8,50 +8,23 @@ tags:
 - Digital Inklusion
 - Webtilgængelighed
 ---
-Når en døv skal bruge informationerne i en video på en kommunal
-hjemmeside, er det vigtigt, at den er tekstet, og når en synshandicappet
-har brug for at kende de gældende regler for forsamlinger, skal teksten
-på myndighedernes websted kunne læses af et skærmlæseprogram.
+Når en døv skal bruge informationerne i en video på en kommunal hjemmeside, er det vigtigt, at den er tekstet, og når en synshandicappet har brug for at kende de gældende regler for forsamlinger, skal teksten på myndighedernes websted kunne læses af et skærmlæseprogram.
 
-Siden efteråret 2020 har det været lovpligtigt, at de offentlige
-websteder skal være tilgængelige for alle borgere uanset eventuelle
-handicap eller funktionsnedsættelser. Senere kommer kravene til også at
-omfatte andre digitale platforme som banker, forsikringsselskaber,
-e-handel og lignende.
+Siden efteråret 2020 har det været lovpligtigt, at de offentlige websteder skal være tilgængelige for alle borgere uanset eventuelle handicap eller funktionsnedsættelser. Senere kommer kravene til også at omfatte andre digitale platforme som banker, forsikringsselskaber, e-handel og lignende.
 
-. Senest
-har de lige før påske indgået en generel aftale med Aalborg Kommune om
-rådgivning og test af tilgængeligheden på de kommunale websteder de
-kommende 12 måneder.
+Senest har de lige før påske indgået en generel aftale med Aalborg Kommune om rådgivning og test af tilgængeligheden på de kommunale websteder de kommende 12 måneder.
 
 ## Supplerer hinanden
 
-De to virksomheder i det nye konsortium er Inklusio ApS og Inqlude IT
-ApS, der nu er flyttet sammen i kontorfællesskabet GrowAAL East i
-Aalborg Øst. Inklusio ApS ledes af Stein Erik Skotkjerra, der har stor
-erfaring med strategisk rådgivning, og har ekspertviden inden for
-webtilgængelighed og digital inklusion, mens Inqlude IT ApS med Orla
-Pedersen i spidsen er en nonprofitvirksomhed med ekspertviden inden for
-webtilgængelighed, brugervenlighed og teknisk rådgivning og uddannelse
-inden for området.
+De to virksomheder i det nye konsortium er Inklusio ApS og Inqlude IT ApS, der nu er flyttet sammen i kontorfællesskabet GrowAAL East i Aalborg Øst. Inklusio ApS ledes af Stein Erik Skotkjerra, der har stor erfaring med strategisk rådgivning, og har ekspertviden inden for webtilgængelighed og digital inklusion, mens Inqlude IT ApS med Orla Pedersen i spidsen er en nonprofitvirksomhed med ekspertviden inden for webtilgængelighed, brugervenlighed og teknisk rådgivning og uddannelse inden for området.
 
-Samtlige medarbejdere hos Inqlude IT ApS var tidligere ansat hos
-virksomheden Special Minds' Aalborg-afdeling, og har for de flestes
-vedkommende en autismeprofil og helt særlige ekspertkompetencer inden
-for IT og webtilgængelighedsområdet.
+Samtlige medarbejdere hos Inqlude IT ApS var tidligere ansat hos virksomheden Special Minds' Aalborg-afdeling, og har for de flestes vedkommende en autismeprofil og helt særlige ekspertkompetencer inden for IT og webtilgængelighedsområdet.
 
--   Vores medarbejdere er særligt uddannede og trænede i at teste
-    tilgængeligheden på de offentlige websteder og mobilapplikationer,
-    forklarer Orla Pedersen.
+-   Vores medarbejdere er særligt uddannede og trænede i at teste tilgængeligheden på de offentlige websteder og mobilapplikationer, forklarer Orla Pedersen.
 
-De to firmaers medarbejdere er vant til at arbejde sammen på projekter
-inden for området, blandt andet har de en omfattende kontrakt med
-Digitaliseringsstyrelsen, som de skal teste 200 websteder for i løbet af
-2021.
+De to firmaers medarbejdere er vant til at arbejde sammen på projekter inden for området, blandt andet har de en omfattende kontrakt med Digitaliseringsstyrelsen, som de skal teste 200 websteder for i løbet af 2021.
 
--   Tilsammen har vi også stor viden om den proces og de intentioner,
-    der ligger bag udvikling af standarden og lovgivningen i Danmark og
-    Europa i øvrigt, oplyser Stein Erik Skotkjerra fra Inklusio ApS.
+-   Tilsammen har vi også stor viden om den proces og de intentioner, der ligger bag udvikling af standarden og lovgivningen i Danmark og Europa i øvrigt, oplyser Stein Erik Skotkjerra fra Inklusio ApS.
 
 *Yderligere oplysninger kan fås ved henvendelse til*
 

--- a/tags-list.njk
+++ b/tags-list.njk
@@ -1,10 +1,9 @@
 ---
 permalink: /tags/
-layout: layouts/home.njk
+layout: layouts/post.njk
+title: Tags
 ---
-<h1>Tags</h1>
-
 {% for tag in collections.tagList %}
   {% set tagUrl %}/tags/{{ tag }}/{% endset %}
-  <a href="{{ tagUrl | url }}" class="tag">{{ tag }}</a>
+  <a href="{{ tagUrl | url }}" class="badge badge-secondary mr-2">{{ tag }}</a>
 {% endfor %}

--- a/tags.njk
+++ b/tags.njk
@@ -10,14 +10,12 @@ pagination:
     - posts
     - tagList
   addAllPagesToCollections: true
-layout: layouts/home.njk
+layout: layouts/post.njk
 renderData:
   title: Tagged “{{ tag }}”
 permalink: /tags/{{ tag }}/
 ---
-<h1>Tagged “{{ tag }}”</h1>
-
+<h1>Artikler markeret med “{{ tag }}”</h1>
 {% set postslist = collections[ tag ] %}
 {% include "postslist.njk" %}
-
-<p>See <a href="{{ '/tags/' | url }}">all tags</a>.</p>
+<p>Se <a href="{{ '/tags/' | url }}">alle tags</a>.</p>


### PR DESCRIPTION
- remove unused ID's
- use proper heading structure
- ensure title doesn't have a "hanging" hyphen when a page lacks a title
- make tags into "badges"
- clean up tags pages
- add bootstrap-inspired utility class for text-decoration
- remove <br /> from news